### PR TITLE
Move log level to front, allow custom logger names

### DIFF
--- a/src/main/java/dev/ayu/latte/logging/Logger.kt
+++ b/src/main/java/dev/ayu/latte/logging/Logger.kt
@@ -23,3 +23,5 @@ inline val Any.log: Logger
     get() = LogManager.getLogger(unwrapCompanionClass(this::class.java))
 
 fun getLogger(clazz: Class<*>): Logger = LogManager.getLogger(clazz)
+
+fun getLogger(name: String): Logger = LogManager.getLogger(name)

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,12 +2,15 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout disableAnsi="false" pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%style{%t}{bright_white}] %style{%logger{36}}{white} / %highlight{%level}{FATAL=bg_bright_red, ERROR=bright_red, WARN=bright_yellow, INFO=bright_green, DEBUG=bright_cyan, TRACE=bright_white}: %msg%n%ex"/>
+            <PatternLayout disableAnsi="false" pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level}{FATAL=bg_bright_red, ERROR=bright_red, WARN=bright_yellow, INFO=bright_green, DEBUG=bright_cyan, TRACE=bright_white} [%style{%t}{bright_white}] %style{%logger{36}}{white}: %msg%n%ex"/>
         </Console>
     </Appenders>
     <Loggers>
         <Root level="DEBUG">
             <AppenderRef ref="Console" />
         </Root>
+        <Logger name="org.apache.kafka" level="WARN">
+            <AppenderRef ref="Console" />
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Previously, the log level was somewhere in the middle, constantly shifting around as thread and logger names changed. This made the levels hard to read and didn't look that nice. Now, the log level is immediately behind the constant-sized date (and is padded by spaces if necessary), so that at a glance you can see what level the message was logged at and can mentally filter them without having to constantly search for the level.

Once you add a slf4j-log4j brigde to tea, you'll notice Kafka streams are... very chatty. _Very_ chatty. They basically spam debug and info logs, so let's limit Kafka logs to warnings only. Thanks Kafka.

Additionally, sometimes one might need a logger but doesn't have easy access to a class, or isn't inside a class (such as when you're inside a Kotlin file with utility functions). This adds a method to create a logger with a custom string name for such cases.