### PR TITLE
Support specifying client in ratelimit data

### DIFF
--- a/src/main/java/dev/ayu/latte/ratelimit/SharedRatelimitData.kt
+++ b/src/main/java/dev/ayu/latte/ratelimit/SharedRatelimitData.kt
@@ -10,6 +10,6 @@ object SharedRatelimitData {
     const val KEY_REQUEST_GLOBAL_QUOTA = "request-global-quota"
 
     @JsonClass(generateAdapter = true)
-    class RatelimitClientData(val requestExpiresAt: Long? = null)
+    class RatelimitClientData(val client: String? = null, val requestExpiresAt: Long? = null)
 
 }


### PR DESCRIPTION
This will allow for matcha to support multiple clients at the same time, with each of them having separate ratelimit buckets, such as beemo vs. max. Otherwise, that would require a completely separate matcha intance on a completely separate Kafka cluster to avoid crosstalk, however in the future we may want to send requests cross-bot-clients so this approach wouldn't work.