### PR TITLE
Support suspending non-blocking send, tweak connection parameters

### DIFF
--- a/src/main/java/dev/ayu/latte/kafka/KafkaClient.kt
+++ b/src/main/java/dev/ayu/latte/kafka/KafkaClient.kt
@@ -115,7 +115,11 @@ open class KafkaClient<T : Any>(
         }
     }
 
-    internal suspend fun respond(msg: KafkaMessage<T>, data: T?) {
+    internal suspend fun respond(
+        msg: KafkaMessage<T>,
+        data: T?,
+        blocking: Boolean = true,
+    ) {
         val newHeaders = KafkaRecordHeaders(
             sourceCluster = currentClusterId,
             targetClusters = setOf(msg.headers.sourceCluster),
@@ -125,6 +129,7 @@ open class KafkaClient<T : Any>(
             msg.key.toResponseKey(),
             data,
             newHeaders,
+            blocking,
         )
     }
 

--- a/src/main/java/dev/ayu/latte/kafka/KafkaClient.kt
+++ b/src/main/java/dev/ayu/latte/kafka/KafkaClient.kt
@@ -37,12 +37,13 @@ open class KafkaClient<T : Any>(
         connection.on(topicName, ::onTopicRecord)
     }
 
-    protected fun send(
+    protected suspend fun send(
         key: String,
         obj: T?,
         headers: KafkaRecordHeaders = KafkaRecordHeaders(currentClusterId),
+        blocking: Boolean = true,
     ): String {
-        return connection.send(topicName, key, stringify(obj), headers)
+        return connection.send(topicName, key, stringify(obj), headers, blocking)
     }
 
     protected suspend fun sendClusterRequest(
@@ -51,6 +52,7 @@ open class KafkaClient<T : Any>(
         timeout: Duration = Duration.ZERO,
         targetClusters: Set<Int> = emptySet(),
         expectedResponses: Int? = null,
+        blocking: Boolean = true,
         messageCallback: KafkaMessageListener<T>? = null,
     ): Pair<Map<Int, KafkaMessage<T>>, Boolean> {
         val responseKey = key.toResponseKey()
@@ -80,7 +82,7 @@ open class KafkaClient<T : Any>(
         var timeoutReached = false
         try {
             requestId.set(
-                send(key, obj, KafkaRecordHeaders(currentClusterId, targetClusters))
+                send(key, obj, KafkaRecordHeaders(currentClusterId, targetClusters), blocking)
             )
 
             if (timeout <= Duration.ZERO) {
@@ -113,7 +115,7 @@ open class KafkaClient<T : Any>(
         }
     }
 
-    internal fun respond(msg: KafkaMessage<T>, data: T?) {
+    internal suspend fun respond(msg: KafkaMessage<T>, data: T?) {
         val newHeaders = KafkaRecordHeaders(
             sourceCluster = currentClusterId,
             targetClusters = setOf(msg.headers.sourceCluster),

--- a/src/main/java/dev/ayu/latte/kafka/KafkaConnection.kt
+++ b/src/main/java/dev/ayu/latte/kafka/KafkaConnection.kt
@@ -195,7 +195,7 @@ class KafkaConnection(
         // "Note that exactly-once processing requires a cluster of at least three brokers by default"
         // - let's hope for the best
         props[StreamsConfig.PROCESSING_GUARANTEE_CONFIG] = StreamsConfig.EXACTLY_ONCE_V2
-        // Commit the stream process every 100ms
+        // Commit the stream progress every 100ms
         props[StreamsConfig.COMMIT_INTERVAL_MS_CONFIG] = 100
 
         val streamsBuilder = StreamsBuilder()

--- a/src/main/java/dev/ayu/latte/kafka/KafkaStructures.kt
+++ b/src/main/java/dev/ayu/latte/kafka/KafkaStructures.kt
@@ -59,7 +59,7 @@ data class KafkaMessage<T : Any>(
     val headers: KafkaRecordHeaders
 ) {
 
-    fun respond(data: T?) {
+    suspend fun respond(data: T?) {
         client.respond(this, data)
     }
 

--- a/src/main/java/dev/ayu/latte/kafka/KafkaStructures.kt
+++ b/src/main/java/dev/ayu/latte/kafka/KafkaStructures.kt
@@ -59,8 +59,8 @@ data class KafkaMessage<T : Any>(
     val headers: KafkaRecordHeaders
 ) {
 
-    suspend fun respond(data: T?) {
-        client.respond(this, data)
+    suspend fun respond(data: T?, blocking: Boolean = true) {
+        client.respond(this, data, blocking)
     }
 
 }

--- a/src/main/java/dev/ayu/latte/util/SuspendingCountDownLatch.kt
+++ b/src/main/java/dev/ayu/latte/util/SuspendingCountDownLatch.kt
@@ -1,5 +1,6 @@
 package dev.ayu.latte.util
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicInteger
@@ -18,7 +19,8 @@ class SuspendingCountDownLatch(initialCount: Int) {
 
     suspend fun countDown() {
         val newValue = counter.decrementAndGet()
-        if (newValue != 0) {
+        @OptIn(ExperimentalCoroutinesApi::class)
+        if (newValue != 0 || channel.isClosedForSend) {
             return
         }
         channel.send(Unit)


### PR DESCRIPTION
Sending a Kafka request was a non-suspending, blocking function previously, which was especially bad for rate limit handling - should Kafkaa go down, the rate limit request would hang during the send timeout, also hanging the Discord request in the process, rendering the entire bot effectively unresponsive.

For situations like this, there is now an option to send the request non-blocking, which does mean you won't be informed if the request fails. But if we're in a context of something like a ratelimit request we can't wait for that to happen anyways, all we care about is the response. Blocking requests will now be fenced into an IO dispatcher and as most callers have been converted to Kotlin by now, we can make the entire function suspending.

There are also changes to some of the Kafka connection parameters. Previously, timeouts were tuned to be very low to avoid situations like the aforementioned one, where we block on a ratelimit request for long periods of time. As it turns out in some testing, this does not seem to work effectively, and since we now support non-blocking sending, we can increase the timeouts again. The reason for doing that is that we don't want to lose records in cases where Kafka goes down shortly, for instance during updates. Instead, we should retry requests for a while. This will be more important in the future, when we move more systems to communicate over Kafka.